### PR TITLE
Add clear-ref-cache action

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Welcome to the Github actions repository! Here you will find a collection of reu
 | [jhonnyvargasarias/actions/create-tag-and-pre-release](./create-tag-and-pre-release/) | Creates a new tag and pre-release on GitHub |
 | [jhonnyvargasarias/actions/update-release](./update-release/)                         | Updates an existing release                 |
 | [jhonnyvargasarias/actions/delete-release](./delete-release/)                         | Deletes a release                           |
+| [jhonnyvargasarias/actions/clear-ref-cache](./clear-ref-cache/)                       | Clears all the values of a given ref        |
 
 Feel free to explore and utilize these actions to enhance your workflows. If you have any questions or need further assistance, please don't hesitate to reach out.

--- a/clear-ref-cache/README.md
+++ b/clear-ref-cache/README.md
@@ -1,0 +1,32 @@
+# <img src="../assets/images/github-actions-logo.png" alt="github actions logo" style="height: 32px"  /> jhonnyvargasarias/actions/clear-ref-cache
+
+## Description
+
+This GitHub Action allows you to clear all the cache keys that have been created for a ref.
+
+## Usage
+
+To use this action, you can include the following step in your workflow:
+
+```yaml
+- name: Clear Ref Cache
+  uses: jhonnyvargasarias/actions/clear-ref-cache@main
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ref: refs/heads/main
+```
+
+## Inputs
+
+| Input          | Required | Description                                                                                                                                      |
+| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `github_token` | Required | The GitHub token used to authenticate the action.<br />You can use `${{ secrets.GITHUB_TOKEN }}` to access the default token provided by GitHub. |
+| `ref`          | Optional | The branch or tag ref where the cache is stored.                                                                                                 |
+
+## Outputs
+
+This action doesn't have any outputs.
+
+---
+
+For more information, you can check out the [GitHub Actions documentation](https://docs.github.com/en/actions).

--- a/clear-ref-cache/action.yml
+++ b/clear-ref-cache/action.yml
@@ -1,0 +1,52 @@
+name: Clear ref cache
+
+inputs:
+  github_token:
+    description: 'GitHub token'
+    type: string
+    required: true
+
+  ref:
+    description: 'Branch or tag ref'
+    default: ${{ github.ref }}
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get ref cache IDs
+      id: get_cache_ids
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const { data } = await github.rest.actions.getActionsCacheList({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: ${{ inputs.ref }},
+          });
+
+          const refCacheIds = data.actions_caches.map(cache => cache.id);
+
+          core.setOutput('ref_cache_ids', JSON.stringify(refCacheIds));
+
+    - name: Clear ref caches
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const refCacheIds = JSON.parse('${{ steps.get_cache_ids.outputs.ref_cache_ids }}' || '[]');
+
+          for (const cacheId of refCacheIds) {
+            await github.rest.actions.deleteActionsCacheById({
+              owner: context.repo.owner,
+              repo: 'portfolio',
+              cache_id: cacheId,
+            });
+          }
+
+          if (refCacheIds.length > 0) {
+            core.notice(`Deleted ${refCacheIds.length} cache(s)`);
+          } else {
+            core.notice('No caches to delete');
+          }


### PR DESCRIPTION
## Description

Some actions or workflow may store cache, which GitHub does not automatically clear.  This action clears the cache of a given ref.